### PR TITLE
fix(boilerplate): restore RootFileName template variable in terragrunt.hcl

### DIFF
--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -21,7 +21,7 @@ locals {
 }
 
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path = find_in_parent_folders("{{ .RootFileName }}")
 }
 
 generate "provider-mongoatlas" {


### PR DESCRIPTION
## Summary

- Restores the `{{ .RootFileName }}` template variable in `.boilerplate/terragrunt.hcl` to replace the hardcoded `root.hcl` string introduced in commit d1c5e07
- The boilerplate is a generic Terragrunt template used by the templating engine; hardcoding `root.hcl` breaks deployments where the root HCL file has a different name
- Fixes the `include "root"` block path to be configuration-driven

## Test plan

- [ ] Verify `.boilerplate/terragrunt.hcl` renders correctly with the template engine using a custom `RootFileName` value
- [ ] Confirm the template still works when `RootFileName` defaults to `root.hcl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)